### PR TITLE
feat: Add context to "from" template

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,7 +12,7 @@ const fastifyMail = async (fastify) => {
       ] = await Promise.all([
         fastify.view(join(templates, 'html'), context),
         fastify.view(join(templates, 'subject'), context),
-        fastify.view(join(templates, 'from'))
+        fastify.view(join(templates, 'from'), context)
       ])
 
       return {


### PR DESCRIPTION
### Summary
This branch adds a small change to allow `from` template access to context. This addition will allow the sender's email to be added as an env variable instead of setting it inside the template itself.